### PR TITLE
refactored log method to check for the desired level of logging

### DIFF
--- a/lib/winston-newrelic.js
+++ b/lib/winston-newrelic.js
@@ -46,7 +46,7 @@ winston.transports.newrelic = WinstonNewrelic;
  * @param {function} callback
  */
 WinstonNewrelic.prototype.log = function(level, msg, meta, callback) {
-    if (level === 'error') {
+    if (level === this.level) {
         this.newrelic.noticeError(msg, meta);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-newrelic-update",
   "description": "Reports winston log errors to new-relic",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "test": "mocha -R spec test/*.js test/*.js"
   },
@@ -23,6 +23,10 @@
     {
       "name": "Yaw Joseph Etse",
       "email": "yaw.etse@gmail.com"
+    },
+    {
+      "name": "Johnny Tordgeman",
+      "email": "johnny@millioneyez.com"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
As the user can define the logging level in the method level parameters, the log function should check against it before sending the log to new relic.
